### PR TITLE
Fix pagination for large number of pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,7 +59,8 @@ haacked-theme:
 # Jekyll Settings
 #
 permalink: /archive/:year/:month/:day/:title/
-paginate: 2
+paginate: 2 # number of posts per page
+page_group_size: 5 # number of pages to group by in the pagination.
 paginate_path: "/archive/page/:num"
 category_dir: categories
 

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,22 +1,36 @@
 <!-- pagination -->
 {% if paginator.total_pages > 1 %}
+{% assign current_modulo = paginator.page | minus: 1 | modulo: site.page_group_size | plus: 1 %}
+{% assign low_page = paginator.page | minus: current_modulo | plus: 1 %}
+{% assign high_page = low_page | plus: site.page_group_size | minus: 1 | at_most: paginator.total_pages %}
 <div class="pagination"> 
   {% if paginator.previous_page %}
     <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Prev</a>
   {% else %}
     <span>&laquo; Prev</span>
   {% endif %}
+  {% if low_page > 1 %}
+    <a href="/">1</a>
 
-  {% for page in (1..paginator.total_pages) %}
+    {% assign previous_page_group = low_page | minus: 1 %}
+    <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', previous_page_group }}">...</a>
+  {% endif %}
+  {% for page in (low_page..high_page) %}
     {% if page == paginator.page %}
-      <span class="webjeda">{{ page }}</span>
+      <span>{{ page }}</span>
     {% elsif page == 1 %}
       <a href="/">{{ page }}</a>
     {% else %}
       <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
     {% endif %}
   {% endfor %}
-
+  {% if paginator.total_pages > high_page %}
+    {% assign next_page_group = high_page | plus: 1 %}
+    {% if next_page_group < paginator.total_pages %}
+    <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', next_page_group }}">...</a>
+    {% endif %}
+    <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', paginator.total_pages }}">{{paginator.total_pages}}</a>
+  {% endif %}
   {% if paginator.next_page %}
     <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Next &raquo;</a>
   {% else %}


### PR DESCRIPTION
My blog could have 199 pages if the page size is 10. Need to make sure we don't render a gigantic pager.

This allows setting a pager group size.